### PR TITLE
例外処理、バリデーションの追加と更新処理の修正

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.3'

--- a/sql/001-create-table-and-load-data.sql
+++ b/sql/001-create-table-and-load-data.sql
@@ -1,7 +1,7 @@
 DROP TABLE IF EXISTS sweets;
 CREATE TABLE sweets (
  id int unsigned AUTO_INCREMENT,
- name VARCHAR(255) NOT NULL,
+ name VARCHAR(255) NOT NULL UNIQUE,
  company VARCHAR(255) NOT NULL,
  price int NOT NULL,
  prefecture VARCHAR(255) NOT NULL,

--- a/src/main/java/com/example/sweets/SweetController.java
+++ b/src/main/java/com/example/sweets/SweetController.java
@@ -1,14 +1,18 @@
 package com.example.sweets;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.util.UriComponentsBuilder;
 
 
 import java.net.URI;
 import java.time.ZonedDateTime;
+import java.util.HashMap;
 import java.util.Map;
 
 @RestController
@@ -24,7 +28,7 @@ public class SweetController {
     }
 
     @PostMapping("/sweets")
-    public ResponseEntity<SweetResponse> insert(@RequestBody SweetRequest sweetRequest, UriComponentsBuilder uriBuilder) {
+    public ResponseEntity<SweetResponse> insert(@RequestBody @Valid SweetRequest sweetRequest, UriComponentsBuilder uriBuilder) {
         Sweet sweet = sweetService.insert(sweetRequest.getName(), sweetRequest.getCompany(), sweetRequest.getPrice(), sweetRequest.getPrefecture());
         URI location = uriBuilder.path("/sweets/{id}").buildAndExpand(sweet.getId()).toUri();
         SweetResponse body = new SweetResponse("sweet created");
@@ -32,7 +36,7 @@ public class SweetController {
     }
 
     @PatchMapping("/sweets/{id}")
-    public ResponseEntity<SweetResponse> update(@PathVariable("id") Integer id, @RequestBody SweetRequest sweetRequest) {
+    public ResponseEntity<SweetResponse> update(@PathVariable("id") Integer id, @RequestBody @Valid SweetRequest sweetRequest) {
         sweetService.update(id, sweetRequest.getName(), sweetRequest.getCompany(), sweetRequest.getPrice(), sweetRequest.getPrefecture());
         SweetResponse body = new SweetResponse("sweet updated");
         return ResponseEntity.ok(body);
@@ -57,4 +61,37 @@ public class SweetController {
                 "path", request.getRequestURI());
             return new ResponseEntity(body, HttpStatus.NOT_FOUND);
         }
+
+    @ExceptionHandler(value = SweetDuplicatedException.class)
+    public ResponseEntity<Map<String, String>> handleSweetDuplicatedException(SweetDuplicatedException e, HttpServletRequest request){
+        Map<String, String> body = Map.of(
+                "timestamp", ZonedDateTime.now().toString(),
+                "status", String.valueOf(HttpStatus.CONFLICT.value()),
+                "error", HttpStatus.CONFLICT.getReasonPhrase(),
+                "message", e.getMessage(),
+                "path", request.getRequestURI());
+        return new ResponseEntity(body, HttpStatus.CONFLICT);
+    }
+
+    @ExceptionHandler(SweetValidationException.class)
+    public ResponseEntity<Map<String, String>> handleSweetValidationException(SweetValidationException e) {
+        Map<String, String> response = new HashMap<>();
+        response.put("timestamp", ZonedDateTime.now().toString());
+        response.put("status", String.valueOf(HttpStatus.BAD_REQUEST.value()));
+        response.put("error", HttpStatus.BAD_REQUEST.getReasonPhrase());
+        response.put("message", e.getMessage());
+        return ResponseEntity.badRequest().body(response);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, String>> handleValidationExceptions(MethodArgumentNotValidException ex) {
+        Map<String, String> errors = new HashMap<>();
+        ex.getBindingResult().getAllErrors().forEach((error) -> {
+            String fieldName = ((FieldError) error).getField();
+            String errorMessage = error.getDefaultMessage();
+            errors.put(fieldName, errorMessage);
+        });
+        return ResponseEntity.badRequest().body(errors);
+    }
+
 }

--- a/src/main/java/com/example/sweets/SweetController.java
+++ b/src/main/java/com/example/sweets/SweetController.java
@@ -52,25 +52,25 @@ public class SweetController {
 
     @ExceptionHandler(value = SweetNotFoundException.class)
     public ResponseEntity<Map<String, String>> handleSweetNotFoundException(
-        SweetNotFoundException e, HttpServletRequest request) {
-            Map<String, String> body = Map.of(
+            SweetNotFoundException e, HttpServletRequest request) {
+        Map<String, String> body = Map.of(
                 "timestamp", ZonedDateTime.now().toString(),
                 "status", String.valueOf(HttpStatus.NOT_FOUND.value()),
                 "error", HttpStatus.NOT_FOUND.getReasonPhrase(),
                 "message", e.getMessage(),
                 "path", request.getRequestURI());
-            return new ResponseEntity(body, HttpStatus.NOT_FOUND);
-        }
+        return new ResponseEntity(body, HttpStatus.NOT_FOUND);
+    }
 
     @ExceptionHandler(value = SweetDuplicatedException.class)
     public ResponseEntity<Map<String, String>> handleSweetDuplicatedException(SweetDuplicatedException e, HttpServletRequest request){
         Map<String, String> body = Map.of(
                 "timestamp", ZonedDateTime.now().toString(),
-                "status", String.valueOf(HttpStatus.CONFLICT.value()),
-                "error", HttpStatus.CONFLICT.getReasonPhrase(),
+                "status", String.valueOf(HttpStatus.BAD_REQUEST.value()),
+                "error", HttpStatus.BAD_REQUEST.getReasonPhrase(),
                 "message", e.getMessage(),
                 "path", request.getRequestURI());
-        return new ResponseEntity(body, HttpStatus.CONFLICT);
+        return new ResponseEntity(body, HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(SweetValidationException.class)
@@ -93,5 +93,4 @@ public class SweetController {
         });
         return ResponseEntity.badRequest().body(errors);
     }
-
 }

--- a/src/main/java/com/example/sweets/SweetDuplicatedException.java
+++ b/src/main/java/com/example/sweets/SweetDuplicatedException.java
@@ -1,0 +1,7 @@
+package com.example.sweets;
+
+public class SweetDuplicatedException extends RuntimeException {
+    public SweetDuplicatedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/sweets/SweetMapper.java
+++ b/src/main/java/com/example/sweets/SweetMapper.java
@@ -13,7 +13,7 @@ public interface SweetMapper {
     @Select("SELECT * FROM sweets WHERE id = #{id}")
     Optional<Sweet> findById(int id);
 
-    @Select("SELECT * FROM sweets WHERE id = #{name}")
+    @Select("SELECT * FROM sweets WHERE name = #{name}")
     Optional<Sweet> findByName(String name);
 
     @Insert("INSERT INTO sweets (name, company, price, prefecture) VALUES (#{name}, #{company}, #{price}, #{prefecture})")
@@ -22,6 +22,7 @@ public interface SweetMapper {
 
     @Update("UPDATE sweets SET name = #{name}, company = #{company}, price = #{price}, prefecture = #{prefecture} WHERE id = #{id}")
     void update(Sweet sweet);
+
 
     @Delete("DELETE FROM sweets WHERE id = #{id}")
     void delete(Integer id);

--- a/src/main/java/com/example/sweets/SweetMapper.java
+++ b/src/main/java/com/example/sweets/SweetMapper.java
@@ -13,6 +13,9 @@ public interface SweetMapper {
     @Select("SELECT * FROM sweets WHERE id = #{id}")
     Optional<Sweet> findById(int id);
 
+    @Select("SELECT * FROM sweets WHERE id = #{name}")
+    Optional<Sweet> findByName(String name);
+
     @Insert("INSERT INTO sweets (name, company, price, prefecture) VALUES (#{name}, #{company}, #{price}, #{prefecture})")
     @Options(useGeneratedKeys = true, keyProperty = "id")
     void insert(Sweet sweet);

--- a/src/main/java/com/example/sweets/SweetRequest.java
+++ b/src/main/java/com/example/sweets/SweetRequest.java
@@ -1,9 +1,17 @@
 package com.example.sweets;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+
 public class SweetRequest {
+
+    @NotBlank
     private String name;
+    @NotBlank
     private String company;
+    @Min(value = 0)
     private int price;
+    @NotBlank
     private String prefecture;
 
     public SweetRequest(String name, String company, int price, String prefecture) {

--- a/src/main/java/com/example/sweets/SweetRequest.java
+++ b/src/main/java/com/example/sweets/SweetRequest.java
@@ -36,4 +36,5 @@ public class SweetRequest {
     public String getPrefecture() {
         return prefecture;
     }
+
 }

--- a/src/main/java/com/example/sweets/SweetService.java
+++ b/src/main/java/com/example/sweets/SweetService.java
@@ -20,7 +20,18 @@ public class SweetService {
         }
     }
 
+
     public Sweet insert(String name, String company, int price, String prefecture) {
+        Optional<Sweet> sweetOptional = this.sweetMapper.findByName(name);
+        if (sweetOptional.isPresent()) {
+            throw new SweetDuplicatedException("Sweets already exists");
+        }
+
+        if (name == null || name.trim().isEmpty() || company == null || company.trim().isEmpty()
+                || prefecture == null || prefecture.trim().isEmpty()) {
+            throw new SweetValidationException("Name, company, and prefecture must not be empty");
+        }
+
         Sweet sweet = new Sweet(null, name, company, price, prefecture);
         sweetMapper.insert(sweet);
         return sweet;
@@ -30,6 +41,10 @@ public class SweetService {
         Optional<Sweet> existingSweet = sweetMapper.findById(id);
         if (!existingSweet.isPresent()) {
             throw new SweetNotFoundException("Sweet not found");
+        }
+        Optional<Sweet> duplicatedSweet = sweetMapper.findByName(name);
+        if (duplicatedSweet.isPresent() && !duplicatedSweet.get().getId().equals(id)) {
+            throw new SweetDuplicatedException("Sweet already exists");
         }
         Sweet sweet = existingSweet.get();
         sweet.setName(name);

--- a/src/main/java/com/example/sweets/SweetValidationException.java
+++ b/src/main/java/com/example/sweets/SweetValidationException.java
@@ -1,0 +1,7 @@
+package com.example.sweets;
+
+public class SweetValidationException extends RuntimeException{
+    public SweetValidationException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
# 概要
例外処理、バリデーションの追加とそれに伴う作成処理と更新処理の修正を行いました。

## 動作確認

現在のMySQLのテーブル

![スクリーンショット 2024-05-31 002310](https://github.com/Rio00o/sweets-service/assets/157946761/2321a6c0-e955-4161-877b-d961e648b524)


すでにある情報を追加しようとすると、HTTPステータスコード 409 Conflict が返ってくる。

![スクリーンショット 2024-05-30 233045](https://github.com/Rio00o/sweets-service/assets/157946761/faa192d5-1d80-40c3-88d3-9108cb9ed750)


カラムが id=5 までしかない状態でid=6でpatchリクエストをすると HTTPステータスコード 404 Not Found が返ってくる。

![スクリーンショット 2024-05-31 001948](https://github.com/Rio00o/sweets-service/assets/157946761/b5865968-4ace-4a1d-a6dd-8800ecfc08eb)


name、company、prefecutre が空欄の場合と priceが0以上でない場合 HTTPステータスコード 400 Bad Request が返ってくる。

![スクリーンショット 2024-05-31 002231](https://github.com/Rio00o/sweets-service/assets/157946761/1981af05-f601-40cf-ae6c-f02ff836ab62)

SweetDuplicatedException において CONFLICT を返していたところを Bad Request を返すように修正しました。
![スクリーンショット 2024-06-02 232512](https://github.com/Rio00o/sweets-service/assets/157946761/ba7d12ef-f7d0-43df-b2e1-adc31cbdac50)
