### PR TITLE
Serviceクラスの Post処理、Delete処理についての単体テストの実装

### DIFF
--- a/src/test/java/com/example/sweets/service/SweetServiceTest.java
+++ b/src/test/java/com/example/sweets/service/SweetServiceTest.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 import static org.springframework.util.Assert.isInstanceOf;
 
@@ -61,5 +62,33 @@ class SweetServiceTest {
         assertThatThrownBy(() -> sweetService.findSweet(0))
             .isInstanceOf(SweetNotFoundException.class);
         verify(sweetMapper).findById(0);
+    }
+
+    @Test
+    public void 新しいスイーツを登録すること () {
+        Sweet sweet = new Sweet("もみじ饅頭", "にしき堂", 1080, "広島県");
+        assertThat(sweetService.insert("もみじ饅頭", "にしき堂", 1080, "広島県")).isEqualTo(sweet);
+        verify(sweetMapper).insert(sweet);
+    }
+
+    @Test
+    public void 存在するスイーツを削除すること () {
+        Integer validId = 1;
+        Sweet existingSweet = new Sweet(1, "博多通りもん", "明月堂", 720, "福岡県");
+        when(sweetMapper.findById(1)).thenReturn(Optional.of(existingSweet));
+        sweetService.delete(validId);
+        verify(sweetMapper).delete(validId);
+    }
+
+    @Test
+    public void 指定したIDにスイーツがない場合は削除できないこと () {
+        Integer invalidId = 999;
+        when(sweetMapper.findById(invalidId)).thenReturn(Optional.empty());
+        Exception exception = assertThrows(SweetNotFoundException.class, () -> {
+            sweetService.delete(999);
+        });
+
+        assertEquals("Sweet not found", exception.getMessage());
+        verify(sweetMapper, never()).delete(invalidId);
     }
 }


### PR DESCRIPTION
# 概要
Serviceクラスのpost処理、delete処理についての単体テストを実装しました。

## 動作確認
新しいスイーツを登録できること
![スクリーンショット 2024-06-12 211507](https://github.com/Rio00o/sweets-service/assets/157946761/c3cf1a84-3107-41da-9e00-71b4416af8f6)

指定したIDにスイーツが存在した場合スイーツを削除できること
![スクリーンショット 2024-06-12 211300](https://github.com/Rio00o/sweets-service/assets/157946761/4d727cb2-d257-4355-a855-d3d120ae6ddf)

指定したIDにスイーツが存在しない場合スイーツを削除できないこと
![スクリーンショット 2024-06-12 211334](https://github.com/Rio00o/sweets-service/assets/157946761/b1c08211-c489-453b-a606-221fa945df8d)
