### PR TITLE
mapperクラスのRead処理のDBテストの実装

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,8 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.3'
+	implementation 'com.github.database-rider:rider-spring:1.42.0'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/sweets/Sweet.java
+++ b/src/main/java/com/example/sweets/Sweet.java
@@ -71,17 +71,34 @@ public class Sweet {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
+
         Sweet sweet = (Sweet) o;
-        return price == sweet.price && Objects.equals(id, sweet.id) && Objects.equals(name, sweet.name) && Objects.equals(company, sweet.company) && Objects.equals(prefecture, sweet.prefecture);
+
+        if (price != sweet.price) return false;
+        if (!Objects.equals(id, sweet.id)) return false;
+        if (!Objects.equals(name, sweet.name)) return false;
+        if (!Objects.equals(company, sweet.company)) return false;
+        return Objects.equals(prefecture, sweet.prefecture);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, company, price, prefecture);
+        int result = id != null ? id.hashCode() : 0;
+        result = 31 * result + (name != null ? name.hashCode() : 0);
+        result = 31 * result + (company != null ? company.hashCode() : 0);
+        result = 31 * result + price;
+        result = 31 * result + (prefecture != null ? prefecture.hashCode() : 0);
+        return result;
     }
 
     @Override
     public String toString() {
-        return "{\"id\":" + id + ",\"name\":\"" + name + "\"company\":" + company + "\"price\":" + price + "\"prefecture\":" + prefecture + "\"}";
+        return "Sweet{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                ", company='" + company + '\'' +
+                ", price=" + price +
+                ", prefecture='" + prefecture + '\'' +
+                '}';
     }
 }

--- a/src/test/java/com/example/sweets/SweetMapperTest.java
+++ b/src/test/java/com/example/sweets/SweetMapperTest.java
@@ -1,0 +1,62 @@
+package com.example.sweets;
+
+import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.spring.api.DBRider;
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.IntPredicate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+
+@DBRider
+@MybatisTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+class SweetMapperTest {
+
+    @Autowired
+    private SweetMapper sweetMapper;
+
+    @Test
+    @DataSet(value = "datasets/sweets.yml")
+    @Transactional
+    void すべてのスイーツが取得できること() {
+        List<Sweet> sweets = sweetMapper.findAll();
+        assertThat(sweets)
+                .hasSize(4)
+                .contains(
+                        new Sweet(1, "博多通りもん", "明月堂", 720, "福岡県"),
+                        new Sweet(2, "萩の月", "菓匠三全", 1500, "宮城県"),
+                        new Sweet(3, "白い恋人", "石屋製菓", 1036, "北海道"),
+                        new Sweet(4, "東京ばな奈", "東京ばな奈ワールド", 1198, "東京都")
+                );
+    }
+
+    @Test
+    @DataSet(value = "datasets/sweets.yml")
+    @Transactional
+    void 指定したIDのスイーツが取得できること () {
+        Optional<Sweet> actual = sweetMapper.findById(1);
+        Sweet sweet1 = new Sweet(1, "博多通りもん", "明月堂", 720, "福岡県");
+        assertThat(actual.get()).isEqualTo(new Sweet(1, "博多通りもん", "明月堂", 720, "福岡県"));
+    }
+
+    @Test
+    @DataSet(value = "datasets/sweets.yml")
+    @Transactional
+    void 存在しないIDを指定した場合は空のOptionalが返ること () {
+        Optional<Sweet> sweets = sweetMapper.findById(999);
+        assertThat(sweets).isEmpty();
+    }
+}

--- a/src/test/resources/datasets/sweets.yml
+++ b/src/test/resources/datasets/sweets.yml
@@ -1,0 +1,21 @@
+sweets:
+  - id: 1
+    name: "博多通りもん"
+    company: "明月堂"
+    price: 720
+    prefecture: "福岡県"
+  - id: 2
+    name: "萩の月"
+    company: "菓匠三全"
+    price: 1500
+    prefecture: "宮城県"
+  - id: 3
+    name: "白い恋人"
+    company: "石屋製菓"
+    price: 1036
+    prefecture: "北海道"
+  - id: 4
+    name: "東京ばな奈"
+    company: "東京ばな奈ワールド"
+    price: 1198
+    prefecture: "東京都"

--- a/src/test/resources/dbunit.yml
+++ b/src/test/resources/dbunit.yml
@@ -1,0 +1,9 @@
+cacheConnection: false
+cacheTableNames: false
+properties:
+  schema: sweet_list
+caseInsensitiveStrategy: LOWERCASE
+connectionConfig:
+  url: "jdbc:mysql://localhost:3307/sweet_list" # MySQLの場合
+  user: "user"
+  password: "password"

--- a/src/test/resources/sqlannotation/delete-sweets.sql
+++ b/src/test/resources/sqlannotation/delete-sweets.sql
@@ -1,0 +1,1 @@
+DELETE FROM sweets;

--- a/src/test/resources/sqlannotation/insert-sweets.sql
+++ b/src/test/resources/sqlannotation/insert-sweets.sql
@@ -1,0 +1,5 @@
+INSERT INTO sweets (name, company, price, prefecture) VALUES ('博多通りもん','明月堂', 720, '福岡県');
+INSERT INTO sweets (name, company, price, prefecture) VALUES ('萩の月', '菓匠三全', 1500, '宮城県');
+INSERT INTO sweets (name, company, price, prefecture) VALUES ('白い恋人', '石屋製菓', 1036, '北海道');
+INSERT INTO sweets (name, company, price, prefecture) VALUES ('東京ばな奈', '東京ばな奈ワールド', 1198, '東京都');
+INSERT INTO sweets (name, company, price, prefecture) VALUES ("もみじ饅頭", "にしき堂", 1080, "広島県");


### PR DESCRIPTION
# 概要
mapperクラスのRead処理のDBテストの実装をしました。

## 動作確認
findAll
![スクリーンショット 2024-06-24 195255](https://github.com/Rio00o/sweets-service/assets/157946761/e3829e25-bf43-445b-9c6b-de4b1f4e832b)

findById(id=1と存在するidを指定したとき)
![スクリーンショット 2024-06-24 195350](https://github.com/Rio00o/sweets-service/assets/157946761/65cfa8d9-dfbe-4c45-b537-a86cbc64f42e)

findById(id=999と存在しないidを指定したとき)
![スクリーンショット 2024-06-24 195411](https://github.com/Rio00o/sweets-service/assets/157946761/27f70a5e-35b3-4b5c-a7af-bb232998a0ad)
