### PR TITLE
Create処理、Update処理、Delete処理のDBテストの実装

### DIFF
--- a/src/main/java/com/example/sweets/SweetMapper.java
+++ b/src/main/java/com/example/sweets/SweetMapper.java
@@ -18,11 +18,10 @@ public interface SweetMapper {
 
     @Insert("INSERT INTO sweets (name, company, price, prefecture) VALUES (#{name}, #{company}, #{price}, #{prefecture})")
     @Options(useGeneratedKeys = true, keyProperty = "id")
-    void insert(Sweet sweet);
+    int insert(Sweet sweet);
 
     @Update("UPDATE sweets SET name = #{name}, company = #{company}, price = #{price}, prefecture = #{prefecture} WHERE id = #{id}")
-    void update(Sweet sweet);
-
+    int update(Sweet sweet);
 
     @Delete("DELETE FROM sweets WHERE id = #{id}")
     void delete(Integer id);

--- a/src/main/java/com/example/sweets/SweetMapper.java
+++ b/src/main/java/com/example/sweets/SweetMapper.java
@@ -18,10 +18,10 @@ public interface SweetMapper {
 
     @Insert("INSERT INTO sweets (name, company, price, prefecture) VALUES (#{name}, #{company}, #{price}, #{prefecture})")
     @Options(useGeneratedKeys = true, keyProperty = "id")
-    int insert(Sweet sweet);
+    void insert(Sweet sweet);
 
     @Update("UPDATE sweets SET name = #{name}, company = #{company}, price = #{price}, prefecture = #{prefecture} WHERE id = #{id}")
-    int update(Sweet sweet);
+    void update(Sweet sweet);
 
     @Delete("DELETE FROM sweets WHERE id = #{id}")
     void delete(Integer id);

--- a/src/main/java/com/example/sweets/SweetNotFoundException.java
+++ b/src/main/java/com/example/sweets/SweetNotFoundException.java
@@ -1,9 +1,7 @@
 package com.example.sweets;
 
-
 public class SweetNotFoundException extends RuntimeException {
     public SweetNotFoundException(String message) {
         super(message);
     }
 }
-

--- a/src/test/java/com/example/sweets/SweetMapperTest.java
+++ b/src/test/java/com/example/sweets/SweetMapperTest.java
@@ -15,6 +15,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.util.ClassUtils.isPresent;
 
 @DBRider
 @MybatisTest
@@ -62,33 +63,28 @@ class SweetMapperTest {
     @Transactional
     void 新しいスイーツが登録できること () {
         Sweet sweet = new Sweet("もみじ饅頭", "にしき堂", 1080, "広島県");
-        int result = sweetMapper.insert(sweet);
-        assertThat(result).isEqualTo(1);
+        sweetMapper.insert(sweet);
+        Optional<Sweet> sweets = sweetMapper.findById(sweet.getId());
+        assertThat(sweets).isPresent();
     }
 
     @Test
     @DataSet(value = "datasets/sweets.yml")
     @Transactional
-    void 存在するIDにスイーツが正しく更新できること() {
+    void 存在するIDにスイーツが正しく更新できること () {
         Optional<Sweet> optionalSweet = sweetMapper.findById(1);
         Sweet sweet = optionalSweet.orElseThrow(() -> new AssertionError("Sweet not found"));
-
         sweet.setName("もみじ饅頭");
         sweet.setCompany("にしき堂");
         sweet.setPrice(1080);
         sweet.setPrefecture("広島県");
 
-        int result = sweetMapper.update(sweet);
-
-        assertThat(result).isEqualTo(1);
+        sweetMapper.update(sweet);
 
         Optional<Sweet> updatedSweetOptional = sweetMapper.findById(1);
         Sweet updatedSweet = updatedSweetOptional.orElseThrow(() -> new AssertionError("Sweet not found"));
 
-        assertThat(updatedSweet.getName()).isEqualTo("もみじ饅頭");
-        assertThat(updatedSweet.getCompany()).isEqualTo("にしき堂");
-        assertThat(updatedSweet.getPrice()).isEqualTo(1080);
-        assertThat(updatedSweet.getPrefecture()).isEqualTo("広島県");
+        assertThat(updatedSweet).isEqualTo(sweet);
     }
 
     @Test


### PR DESCRIPTION
# 概要
Create処理、Update処理、Delete処理のDBテストの実装しました。

## 動作確認
- Create 処理
![スクリーンショット 2024-06-27 032320](https://github.com/Rio00o/sweets-service/assets/157946761/e2e97d5c-0da9-4d51-8a45-5ae7157aac27)

- Update 処理
![スクリーンショット 2024-06-27 032400](https://github.com/Rio00o/sweets-service/assets/157946761/f3c30312-c98a-41a9-bb1d-e62d98810a95)


- Delete 処理
![スクリーンショット 2024-06-27 032428](https://github.com/Rio00o/sweets-service/assets/157946761/a4f06a18-9567-4d3b-b4fc-b65408f030c3)
