### PR TITLE
create処理、update処理の結合テストとそれらの例外処理の実装、read処理の例外処理の一部訂正

### DIFF
--- a/src/test/resources/sqlannotation/update-sweets.sql
+++ b/src/test/resources/sqlannotation/update-sweets.sql
@@ -1,9 +1,9 @@
 sweets:
     - id: 1
-    - name: "博多通りもん"
-    - company: "明月堂"
-    - price: 720
-    - prefecture: "福岡県"
+    - name: "もみじ饅頭"
+    - company: "にしき堂"
+    - price: 1080
+    - prefecture: "広島県"
 
     - id: 2
     - name: "萩の月"
@@ -22,9 +22,3 @@ sweets:
     - company: "東京ばな奈ワールド"
     - price: 1198
     - prefecture: "東京都"
-
-    - id: 5
-    - name: "もみじ饅頭"
-    - company: "にしき堂"
-    - price: 1080
-    - prefecture: "広島県"


### PR DESCRIPTION
# 概要
create処理、update処理の結合テストとそれらの例外処理の実装をしました。
read処理の例外処理についてメソッド名を変更しました。

## 動作確認
![image](https://github.com/Rio00o/sweets-service/assets/157946761/8b6a6e2c-d7f7-46fc-bbce-bfe78f16a324)
![スクリーンショット 2024-07-11 042803](https://github.com/Rio00o/sweets-service/assets/157946761/800c3d67-5834-43f8-a80f-75376528807d)
![スクリーンショット 2024-07-11 042749](https://github.com/Rio00o/sweets-service/assets/157946761/95fac41b-855a-4ff8-9b8a-c4b61e0d8369)

### 指定したIDにスイーツが存在しない場合更新できないことを確認するテストについて
- ID=1の場合
![スクリーンショット 2024-07-11 045126](https://github.com/Rio00o/sweets-service/assets/157946761/c66c7afa-7f9e-4426-9443-e82a4a3b2c92)

- ID=999の場合
![スクリーンショット 2024-07-11 043554](https://github.com/Rio00o/sweets-service/assets/157946761/fa00d1bf-3e9e-4b8e-9584-4b00cb4bfb9f)
