### PR TITLE
create,updateの結合処理に@ExpectedDataSetを追加、createの結合処理の修正、@DataSetの()内を統一

### DIFF
--- a/sql/001-create-table-and-load-data.sql
+++ b/sql/001-create-table-and-load-data.sql
@@ -11,4 +11,3 @@ INSERT INTO sweets (name, company, price, prefecture) VALUES ('博多通りも�
 INSERT INTO sweets (name, company, price, prefecture) VALUES ('萩の月', '菓匠三全', 1500, '宮城県');
 INSERT INTO sweets (name, company, price, prefecture) VALUES ('白い恋人', '石屋製菓', 1036, '北海道');
 INSERT INTO sweets (name, company, price, prefecture) VALUES ('東京ばな奈', '東京ばな奈ワールド', 1198, '東京都');
-

--- a/src/test/java/com/example/sweets/integrationtest/SweetApiIntegrationTest.java
+++ b/src/test/java/com/example/sweets/integrationtest/SweetApiIntegrationTest.java
@@ -1,7 +1,5 @@
 package com.example.sweets.integrationtest;
 
-import com.example.sweets.Sweet;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.core.api.dataset.ExpectedDataSet;
 import com.github.database.rider.spring.api.DBRider;
@@ -92,21 +90,26 @@ public class SweetApiIntegrationTest {
     }
 
     @Test
-    @DataSet("datasets/sweets.yml")
+    @DataSet(value = "datasets/sweets.yml")
+    @ExpectedDataSet(value = "datasets/insert-sweets.yml", ignoreCols = "id")
     @Transactional
     void 新しくスイーツを登録すること() throws Exception {
-        Sweet sweet = new Sweet("もみじ饅頭", "にしき堂", 1080, "広島県");
-        ObjectMapper objectMapper = new ObjectMapper();
-        String result = objectMapper.writeValueAsString(sweet);
-
         mockMvc.perform(MockMvcRequestBuilders.post("/sweets")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(result))
+                        .content("""
+                                {
+                                    "name": "もみじ饅頭",
+                                    "company": "にしき堂",
+                                    "price": 1080,
+                                    "prefecture": "広島県"
+                                }
+                                """))
                 .andExpect(MockMvcResultMatchers.status().isCreated());
     }
 
     @Test
-    @DataSet("datasets/sweets.yml")
+    @DataSet(value = "datasets/sweets.yml")
+    @ExpectedDataSet(value = "datasets/update-sweets.yml")
     @Transactional
     void 存在するスイーツを新しく更新すること() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.patch("/sweets/1")
@@ -123,7 +126,7 @@ public class SweetApiIntegrationTest {
     }
 
     @Test
-    @DataSet("datasets/sweets.yml")
+    @DataSet(value = "datasets/sweets.yml")
     @Transactional
     void すでに存在するスイーツと重複して更新しようとした場合更新できないこと() throws Exception {
         String duplicateSweetJson = """
@@ -141,7 +144,7 @@ public class SweetApiIntegrationTest {
     }
 
     @Test
-    @DataSet("datasets/sweets.yml")
+    @DataSet(value = "datasets/sweets.yml")
     @Transactional
     void 指定したIDにスイーツが存在しない場合更新できないこと() throws Exception {
         String NotFoundException = """
@@ -159,7 +162,7 @@ public class SweetApiIntegrationTest {
     }
 
     @Test
-    @DataSet("datasets/sweets.yml")
+    @DataSet(value = "datasets/sweets.yml")
     @ExpectedDataSet("datasets/delete-sweets.yml")
     @Transactional
     void 存在するスイーツを正しく削除できること() throws Exception {
@@ -169,7 +172,7 @@ public class SweetApiIntegrationTest {
     }
 
     @Test
-    @DataSet("datasets/sweets.yml")
+    @DataSet(value = "datasets/sweets.yml")
     @Transactional
     void 指定したIDにスイーツがない場合は削除できないこと() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.delete("/sweets/999")

--- a/src/test/resources/datasets/sweets.yml
+++ b/src/test/resources/datasets/sweets.yml
@@ -4,16 +4,19 @@ sweets:
     company: "明月堂"
     price: 720
     prefecture: "福岡県"
+
   - id: 2
     name: "萩の月"
     company: "菓匠三全"
     price: 1500
     prefecture: "宮城県"
+
   - id: 3
     name: "白い恋人"
     company: "石屋製菓"
     price: 1036
     prefecture: "北海道"
+
   - id: 4
     name: "東京ばな奈"
     company: "東京ばな奈ワールド"


### PR DESCRIPTION
# 概要
- create,updateの結合処理にテスト実行後のテーブル内を確認するために@ExpectedDataSetを追加しました。

- createの結合処理をシンプルな形(他のメソッドに似た形)に修正しました。

- @DataSetを@DataSet(value = "datasets/sweets.yml")に統一しました。

## 動作確認

![スクリーンショット 2024-07-14 210359](https://github.com/user-attachments/assets/1b73b3b8-f36f-4c47-80bc-1dc4ef809100)

![スクリーンショット 2024-07-14 210413](https://github.com/user-attachments/assets/47eb6c1a-8043-4a1b-b2ec-eb73b2cf6322)

![image](https://github.com/user-attachments/assets/6f83179e-b498-49c8-8b09-7ada0996512d)